### PR TITLE
keep footer at bottom

### DIFF
--- a/src/Bootstrap3.3.7/bootstrapOverrides.css
+++ b/src/Bootstrap3.3.7/bootstrapOverrides.css
@@ -1,0 +1,3 @@
+div.jumbotron {
+  background-color: rgba(220,250,250,1);
+}

--- a/src/Layout/components/footer.js
+++ b/src/Layout/components/footer.js
@@ -8,7 +8,7 @@ import {
 export default class ThankYou extends Component {
   render() {
     return(
-      <footer>
+      <footer className='footer'>
         <Grid>
           <Row className="subFooter">
             <Col xs={12} className="text-center">

--- a/src/Layout/layout.js
+++ b/src/Layout/layout.js
@@ -2,13 +2,17 @@ import React, { Component } from 'react';
 import Header from './components/header.js'
 import Footer from './components/footer.js'
 
+import './style/layout.css'
+
 export default class Layout extends Component {
 
   render() {
     return (
-      <div>
-        <Header/>
-          {this.props.children}
+      <div className='layout'>
+        <div className='full-height'>
+          <Header/>
+            {this.props.children}
+        </div>
         <Footer/>
       </div>
     )

--- a/src/Layout/style/layout.css
+++ b/src/Layout/style/layout.css
@@ -1,0 +1,4 @@
+.layout .full-height {
+  position: relative;
+  min-height: calc(100vh - 130px);
+}

--- a/src/ThankYou/components/thankYou.js
+++ b/src/ThankYou/components/thankYou.js
@@ -1,14 +1,22 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
+import {
+    Grid,
+    Row,
+    Col,
+    Jumbotron,
+    Button,
+} from 'react-bootstrap'
 
 export default class ThankYou extends Component {
   render() {
     return(
-      <div>
-        <h1>Thank You Page Under Construction</h1>
-        <Link to='/'>Landing page link</Link>
-        <Link to='/donation-form'>Donation form link</Link>
-      </div>
+      <Grid>
+        <Jumbotron>
+          <Row className='text-center'>
+            <p>Thank you for your submission. Please check your email for a confirmation.</p>
+          </Row>
+        </Jumbotron>
+      </Grid>
     )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom'
 import './index.css';
+import './Bootstrap3.3.7/bootstrapOverrides.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 


### PR DESCRIPTION
This PR has some minor style and layout tweaks 

- Keeps footer at bottom (especially on relatively empty pages like ThankYou page)
- Adds a BootstrapOverrides.css file to store any custom styles overriding bootstrap